### PR TITLE
bug fix in n-back.js

### DIFF
--- a/assets/js/n-back.js
+++ b/assets/js/n-back.js
@@ -197,13 +197,13 @@ function startCurrentBlock() {
     $('#action-buttons').append(
         $('<div>').addClass('ui two large buttons').append(
             $('<div>').addClass('ui positive left labeled icon button').html('<i class="arrow left icon"></i>Target').click(function () {
-                markAsTarget();
+                markAsTarget(new Date());
             })
         ).append(
             $('<div>').addClass('or')
         ).append(
             $('<div>').addClass('ui negative right labeled icon button').html('Non-Target<i class="arrow right icon"></i>').click(function () {
-                markAsNonTarget();
+                markAsNonTarget(new Date());
             })
         ).append(
             $('<audio>').attr({


### PR DESCRIPTION
Fixed bug that prevented clicking the buttons to register participant answers.

markAsTarget() and markAsNonTarget() on positive and negative divs click events were missing the Date argument, so clicking them to submit answers was not possible. This patch fixes that.