### PR TITLE
Fix 0-back task

### DIFF
--- a/assets/js/n-back.js
+++ b/assets/js/n-back.js
@@ -37,19 +37,36 @@ function generateBlock(level,
     var unloadTime = loadTime + loadInterval;
     if (level === 0) {
         for (var i = 0; i < totalSize; i++) {
-            stimuli.push({
-                'stimulus': _.sample(stimuliPool),
-                'is_target': true,
-                'load_time': loadTime,
-                'unload_time': unloadTime,
-                'answer': null,
-                'correct': null,
-                'response_time': null,
-                'timestamp': {
-                    'load': null,
-                    'response': null
-                }
-            });
+            if (_.random(1, totalSize - i) <= targetSize) {
+                targetSize--;
+                stimuli.push({
+                    'stimulus': 'X',
+                    'is_target': true,
+                    'load_time': loadTime,
+                    'unload_time': unloadTime,
+                    'answer': null,
+                    'correct': null,
+                    'response_time': null,
+                    'timestamp': {
+                        'load': null,
+                        'response': null
+                    }
+                });
+            } else {
+                stimuli.push({
+                    'stimulus': _.sample(_.difference(stimuliPool, ['X'])),
+                    'is_target': false,
+                    'load_time': loadTime,
+                    'unload_time': unloadTime,
+                    'answer': null,
+                    'correct': null,
+                    'response_time': null,
+                    'timestamp': {
+                        'load': null,
+                        'response': null
+                    }
+                });
+            };
             loadTime += interval;
             unloadTime += interval;
         };


### PR DESCRIPTION
0-back task was setting every stimulus as a target. This was fixed to generate a target number of characters 'X',  with all other characters being non-targets.